### PR TITLE
Make shadows work cross browser

### DIFF
--- a/layervis.js
+++ b/layervis.js
@@ -217,11 +217,12 @@ var LAYERVIS_PERSPECTIVE = 1000;
               opacity: interpolateCap(
                   progress(distance, MAX_SHADOW_DARK_AT, MIN_SHADOW_DARK_AT),
                   MAX_SHADOW_DARK, MIN_SHADOW_DARK),
+              'filter': 'blur(' + interpolateCap(progress(distance, 0, 5), MIN_SHADOW_BLUR, MAX_SHADOW_BLUR) + 'px)',
               '-webkit-filter': 'blur(' + interpolateCap(progress(distance, 0, 5), MIN_SHADOW_BLUR, MAX_SHADOW_BLUR) + 'px)'
             });
 
         var computedStyle = getComputedStyle(topLayer.$.get(0));
-        $shadow.css('border-radius', computedStyle.borderRadius);
+        $shadow.css('border-radius', computedStyle.borderTopLeftRadius);
         $shadow.appendTo(bottomLayer.$);
       }
     }


### PR DESCRIPTION
I'm not entirely sure why Firefox doesn't return CSS shorthands in getComputedStyle, but it doesn't. This PR adds the standard filter property and gets the existing border radius from border-top-left-radius instead of the shorthand.
